### PR TITLE
Fix item cycling from emptying quiver

### DIFF
--- a/noudar-core/include/CActor.h
+++ b/noudar-core/include/CActor.h
@@ -110,6 +110,8 @@ namespace Knights {
 		std::string getCurrentSay();
 
 		void copyStateFrom( std::shared_ptr<CActor> other );
+
+		void suggestCurrentItem( char view );
 	protected:
 
 		void setCurrentSay( std::string newSay );

--- a/noudar-core/src/CActor.cpp
+++ b/noudar-core/src/CActor.cpp
@@ -225,6 +225,14 @@ namespace Knights {
 		this->mInventory = this->mInventory;
 	}
 
+    void CActor::suggestCurrentItem( char view ) {
+        auto item = getItemWithSymbol( view );
+
+        if ( item != nullptr ) {
+            mCurrentItem = item;
+        }
+    }
+
     std::shared_ptr<CItem> CActor::getItemWithSymbol(char symbol) {
 
 		for ( const auto& item : mInventory ) {

--- a/noudar-core/src/CMap.cpp
+++ b/noudar-core/src/CMap.cpp
@@ -122,6 +122,7 @@ namespace Knights {
 
                             if ( static_cast<CStorageItem*>(&(*quiver))->add( -1 ) == 0) {
                                 aActor->removeItemFromInventory( quiver );
+                                aActor->suggestCurrentItem('y');
                             }
                         });
 		                break;

--- a/noudar-core/src/CRandomWorldGenerator.cpp
+++ b/noudar-core/src/CRandomWorldGenerator.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <memory>
+#include <array>
 #include <sstream>
 #include <vector>
 #include <random>


### PR DESCRIPTION
Fix #7 

After firing the the last dart on a quiver, just after disposing the empty quiver, the crossbow will suggest to the actor to select itself back as the active item.

![screenshot from 2017-04-12 22-17-05](https://cloud.githubusercontent.com/assets/2441483/24980041/635e5d8c-1fce-11e7-9835-b002ad86d8d7.png)
![screenshot from 2017-04-12 22-17-12](https://cloud.githubusercontent.com/assets/2441483/24980039/635be110-1fce-11e7-8e3e-359b00b4b0e0.png)
![screenshot from 2017-04-12 22-17-16](https://cloud.githubusercontent.com/assets/2441483/24980040/635d2c46-1fce-11e7-9595-03f2d7b62b22.png)
