### PR TITLE
Fix inventory handover after level transition

### DIFF
--- a/noudar-core/src/CActor.cpp
+++ b/noudar-core/src/CActor.cpp
@@ -229,7 +229,7 @@ namespace Knights {
 		this->mStance = other->mStance;
 		this->mTeam = other->mTeam;
 		this->mHP = other->mHP;
-		this->mInventory = this->mInventory;
+		this->mInventory = other->mInventory;
 	}
 
     void CActor::suggestCurrentItem( char view ) {


### PR DESCRIPTION
There were issues where the current item was retained but upon using it,
the callback would query it from the inventory and it would not be
found.

Before:
![screenshot from 2017-05-02 21-24-33](https://cloud.githubusercontent.com/assets/2441483/25638045/fd885074-2f7e-11e7-889b-d11e0d7dc8e8.png)
![screenshot from 2017-05-02 21-24-56](https://cloud.githubusercontent.com/assets/2441483/25638047/fe328df0-2f7e-11e7-8163-68d38217962e.png)

After:
![screenshot from 2017-05-02 21-25-45](https://cloud.githubusercontent.com/assets/2441483/25638055/048a9b66-2f7f-11e7-9c85-242ae7be3545.png)
![screenshot from 2017-05-02 21-25-55](https://cloud.githubusercontent.com/assets/2441483/25638057/04b98958-2f7f-11e7-8bf1-6efed57f4144.png)
![screenshot from 2017-05-02 21-25-58](https://cloud.githubusercontent.com/assets/2441483/25638056/04a4d09e-2f7f-11e7-9712-f4ee2af7155d.png)
